### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,15 +1,13 @@
 name: Run PR Tests
-
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
     types:
       - opened
       - synchronize
       - reopened
-
-permissions:
-  contents: read
-  pull-requests: write
 
 jobs:
   build-project:

--- a/.github/workflows/rename.yml
+++ b/.github/workflows/rename.yml
@@ -1,5 +1,4 @@
 name: Rename Template Repository
-
 on:
   workflow_dispatch:  # Allows manual triggering
 

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,4 +1,6 @@
 name: Update Gradle Wrapper
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,6 +1,7 @@
 name: Update Gradle Wrapper
 permissions:
   contents: read
+  pull-requests: write
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/RegrowthMC/ProjectTemplate/security/code-scanning/6](https://github.com/RegrowthMC/ProjectTemplate/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the actions used (`actions/checkout` and `gradle-update/update-gradle-wrapper-action`), the workflow likely needs `contents: read` to access the repository's files and potentially `contents: write` if it modifies files. However, since the workflow does not explicitly indicate file modifications, we will start with `contents: read` and adjust if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
